### PR TITLE
Use `safelist` for PostCSS 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple wrapper around `postcss-purgecss` with sensible defaults for Laravel ap
 module.exports = {
     plugins: [
         require('postcss-purgecss-laravel')({
-            whitelistPatterns: [/hljs/],
+            safelist: [/hljs/],
             extend: {
                 content: [content: [path.join(__dirname, 'vendor/spatie/menu/**/*.php')],]
             },
@@ -63,7 +63,7 @@ All options passed to the plugin get passed down to PurgeCSS. Refer to the [Purg
 module.exports = {
     plugins: [
         require('postcss-purgecss-laravel')({
-            whitelistPatterns: [/hljs/],
+            safelist: [/hljs/],
         }),
     ],
 };
@@ -78,14 +78,14 @@ module.exports = {
     plugins: [
         require('postcss-purgecss-laravel')({
             extend: {
-                whitelistPatterns: [/hljs/],
+                safelist: [/hljs/],
             },
         }),
     ],
 };
 ```
 
-In the above example, the `/hljs/` pattern will be _added_ to the `whitelistPatterns`, instead of overriding the default `whitelistPatterns` option.
+In the above example, the `/hljs/` pattern will be _added_ to the `safelist`, instead of overriding the default `safelist` option.
 
 These are the defaults this package provides:
 
@@ -103,7 +103,7 @@ const defaultConfig = {
         "resources/**/*.twig",
     ],
     defaultExtractor: (content) => content.match(/[\w-/.:]+(?<!:)/g) || [],
-    whitelistPatterns: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
+    safelist: [/-active$/, /-enter$/, /-leave-to$/, /show$/],
 };
 ```
 

--- a/__test__/__snapshots__/createConfig.test.js.snap
+++ b/__test__/__snapshots__/createConfig.test.js.snap
@@ -23,7 +23,7 @@ Object {
       /show\\$/,
     ],
   },
-  "whitelistPatterns": Array [],
+  "safelist": Array [],
 }
 `;
 

--- a/__test__/createConfig.test.js
+++ b/__test__/createConfig.test.js
@@ -24,7 +24,7 @@ test("it can extend the default config", () => {
 
 test("it can extend and override the default config", () => {
     const config = {
-        whitelistPatterns: [],
+        safelist: [],
         extend: {
             content: ["vendor/spatie/menu/**/*.php"],
         },


### PR DESCRIPTION
This simply replaces all occurrences of `whitelistPatterns` with the new, correct `safelist` keyword. Took me a while to notice that PostCSS 3 replaced the keyword and the readme was outdated 😄